### PR TITLE
Fix: OAuth Google Signin

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -71,6 +71,7 @@ export const authOptions: AuthOptions = {
             },
             body: JSON.stringify(userUpdates),
           });
+          return true;
         }
         return true;
       }


### PR DESCRIPTION
This fixes an issue for signing in with google OAuth on a user that was already created by the signup page with the same email.
fun fact, Vercel preview deploys are dynamic so I can't add the url as an authorized origin to the google OAuth. Production should be fine though. 